### PR TITLE
Ensure popup spinner style is reused and cleaned up

### DIFF
--- a/openPopup.js
+++ b/openPopup.js
@@ -28,10 +28,19 @@
       overlay.style.opacity = '1';
     });
     
+    // Helper to remove overlay and associated styles
+    const removePopup = () => {
+      document.body.removeChild(overlay);
+      const existingStyle = document.getElementById('popup-spinner-style');
+      if (existingStyle) {
+        existingStyle.remove();
+      }
+    };
+
     // Close popup if clicking outside the box
     overlay.addEventListener('click', (event) => {
       if (event.target === overlay) {
-        document.body.removeChild(overlay);
+        removePopup();
       }
     });
 
@@ -58,9 +67,7 @@
     closeBtn.style.color = brandColor;
     closeBtn.style.fontSize = '35px';
     closeBtn.style.cursor = 'pointer';
-    closeBtn.onclick = () => {
-      document.body.removeChild(overlay);
-    };
+    closeBtn.onclick = removePopup;
     popup.appendChild(closeBtn);
 
     // Create iframe
@@ -85,16 +92,20 @@
     preloader.style.animation = 'spin 1s linear infinite';
     overlay.appendChild(preloader);
 
-    // Add keyframes for preloader animation
-    const styleSheet = document.createElement("style");
-    styleSheet.type = "text/css";
-    styleSheet.innerText = `
-      @keyframes spin {
-        0% { transform: rotate(0deg); }
-        100% { transform: rotate(360deg); }
-      }
-    `;
-    document.head.appendChild(styleSheet);
+    // Add keyframes for preloader animation if not already present
+    let styleSheet = document.getElementById('popup-spinner-style');
+    if (!styleSheet) {
+      styleSheet = document.createElement('style');
+      styleSheet.id = 'popup-spinner-style';
+      styleSheet.type = 'text/css';
+      styleSheet.innerText = `
+        @keyframes spin {
+          0% { transform: rotate(0deg); }
+          100% { transform: rotate(360deg); }
+        }
+      `;
+      document.head.appendChild(styleSheet);
+    }
 
     // Wait for iframe to load and then fade in popup
     iframe.onload = () => {

--- a/openPopup.test.js
+++ b/openPopup.test.js
@@ -1,0 +1,115 @@
+class Element {
+  constructor(tagName) {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.style = {};
+    this.attributes = {};
+    this.eventListeners = {};
+    this.parentNode = null;
+    this.onclick = null;
+    this.innerText = '';
+  }
+  appendChild(child) {
+    child.parentNode = this;
+    this.children.push(child);
+    return child;
+  }
+  removeChild(child) {
+    this.children = this.children.filter(c => c !== child);
+    child.parentNode = null;
+  }
+  remove() {
+    if (this.parentNode) {
+      this.parentNode.removeChild(this);
+    }
+  }
+  set id(val) { this.attributes.id = val; }
+  get id() { return this.attributes.id; }
+  set className(val) { this.attributes.className = val; }
+  get className() { return this.attributes.className || ''; }
+  addEventListener(evt, handler) { this.eventListeners[evt] = handler; }
+  dispatchEvent(evt) {
+    const handler = this.eventListeners[evt.type];
+    if (handler) handler(evt);
+  }
+  click() {
+    if (typeof this.onclick === 'function') {
+      this.onclick({ target: this });
+    }
+    this.dispatchEvent({ type: 'click', target: this });
+  }
+  querySelector(selector) {
+    for (const child of this.children) {
+      if (selector.startsWith('.')) {
+        if (child.className === selector.slice(1)) return child;
+      } else if (selector.startsWith('#')) {
+        if (child.id === selector.slice(1)) return child;
+      } else if (child.tagName.toLowerCase() === selector.toLowerCase()) {
+        return child;
+      }
+      const found = child.querySelector(selector);
+      if (found) return found;
+    }
+    return null;
+  }
+  getElementById(id) {
+    if (this.id === id) return this;
+    for (const child of this.children) {
+      const found = child.getElementById(id);
+      if (found) return found;
+    }
+    return null;
+  }
+}
+
+const document = {
+  head: new Element('head'),
+  body: new Element('body'),
+  createElement(tag) { return new Element(tag); },
+  querySelector(selector) {
+    return this.head.querySelector(selector) || this.body.querySelector(selector);
+  },
+  getElementById(id) {
+    return this.head.getElementById(id) || this.body.getElementById(id);
+  }
+};
+
+global.document = document;
+
+global.window = { document };
+
+global.requestAnimationFrame = (cb) => cb();
+
+require('./openPopup.js');
+
+function openAndClose() {
+  window.openPopup('about:blank');
+  const styleTag = document.getElementById('popup-spinner-style');
+  if (!styleTag) {
+    throw new Error('Style tag was not created');
+  }
+  const overlay = document.querySelector('.popup-overlay');
+  if (!overlay) {
+    throw new Error('Overlay not created');
+  }
+  const preloader = overlay.children[overlay.children.length - 1];
+  if (preloader.style.animation !== 'spin 1s linear infinite') {
+    throw new Error('Preloader animation missing');
+  }
+  const closeBtn = overlay.querySelector('button');
+  if (!closeBtn) {
+    throw new Error('Close button missing');
+  }
+  closeBtn.click();
+  if (document.getElementById('popup-spinner-style')) {
+    throw new Error('Style tag not removed');
+  }
+  if (document.querySelector('.popup-overlay')) {
+    throw new Error('Overlay not removed');
+  }
+}
+
+openAndClose();
+openAndClose();
+
+console.log('All tests passed');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bf-popup",
+  "version": "1.0.0",
+  "description": "",
+  "main": "openPopup.js",
+  "scripts": {
+    "test": "node openPopup.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
## Summary
- Give preloader style tag a unique `popup-spinner-style` id, avoiding duplicates
- Remove overlay and spinner style when popup closes
- Add tests to confirm popup can be opened and closed repeatedly without leftover styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0f4392ec8326bcee5048b95ff417