### PR TITLE
Handle Escape key to close popup

### DIFF
--- a/openPopup.js
+++ b/openPopup.js
@@ -23,19 +23,28 @@
     overlay.style.transition = 'opacity 0.4s ease-in';
     document.body.appendChild(overlay);
 
-    // Fade in overlay
-    requestAnimationFrame(() => {
-      overlay.style.opacity = '1';
-    });
-    
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        removePopup();
+      }
+    };
+
     // Helper to remove overlay and associated styles
     const removePopup = () => {
+      document.removeEventListener('keydown', handleKeyDown);
       document.body.removeChild(overlay);
       const existingStyle = document.getElementById('popup-spinner-style');
       if (existingStyle) {
         existingStyle.remove();
       }
     };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    // Fade in overlay
+    requestAnimationFrame(() => {
+      overlay.style.opacity = '1';
+    });
 
     // Close popup if clicking outside the box
     overlay.addEventListener('click', (event) => {

--- a/openPopup.test.js
+++ b/openPopup.test.js
@@ -65,12 +65,23 @@ class Element {
 const document = {
   head: new Element('head'),
   body: new Element('body'),
+  eventListeners: {},
   createElement(tag) { return new Element(tag); },
   querySelector(selector) {
     return this.head.querySelector(selector) || this.body.querySelector(selector);
   },
   getElementById(id) {
     return this.head.getElementById(id) || this.body.getElementById(id);
+  },
+  addEventListener(evt, handler) { this.eventListeners[evt] = handler; },
+  removeEventListener(evt, handler) {
+    if (this.eventListeners[evt] === handler) {
+      delete this.eventListeners[evt];
+    }
+  },
+  dispatchEvent(evt) {
+    const handler = this.eventListeners[evt.type];
+    if (handler) handler(evt);
   }
 };
 
@@ -96,16 +107,17 @@ function openAndClose() {
   if (preloader.style.animation !== 'spin 1s linear infinite') {
     throw new Error('Preloader animation missing');
   }
-  const closeBtn = overlay.querySelector('button');
-  if (!closeBtn) {
-    throw new Error('Close button missing');
-  }
-  closeBtn.click();
+
+  document.dispatchEvent({ type: 'keydown', key: 'Escape' });
+
   if (document.getElementById('popup-spinner-style')) {
     throw new Error('Style tag not removed');
   }
   if (document.querySelector('.popup-overlay')) {
     throw new Error('Overlay not removed');
+  }
+  if (document.eventListeners.keydown) {
+    throw new Error('Keydown listener not removed');
   }
 }
 


### PR DESCRIPTION
## Summary
- Close popup with Escape key and clean up listener
- Ensure tests simulate Escape key closure and verify listener removal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac125996b48326a88eedb3b19f5ca9