### PR TITLE
Fix spinner centering

### DIFF
--- a/openPopup.js
+++ b/openPopup.js
@@ -120,8 +120,8 @@
       styleSheet.type = 'text/css';
       styleSheet.innerText = `
         @keyframes spin {
-          0% { transform: rotate(0deg); }
-          100% { transform: rotate(360deg); }
+          0% { transform: translate(-50%, -50%) rotate(0deg); }
+          100% { transform: translate(-50%, -50%) rotate(360deg); }
         }
       `;
       document.head.appendChild(styleSheet);


### PR DESCRIPTION
## Summary
- Keep popup spinner centered while rotating by combining translation and rotation in keyframes.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac1d4f6f0c8326acbff3271d6b0d95